### PR TITLE
Improve error parsing for analysis request

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -197,13 +197,18 @@ export function AppProvider({ children }) {
         })
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || `API request failed with status ${response.status}`);
+      const rawText = await response.text();
+      let data;
+      try {
+        data = JSON.parse(rawText);
+      } catch {
+        throw new Error(rawText || `API request failed with status ${response.status}`);
       }
 
-      const data = await response.json();
-      
+      if (!response.ok) {
+        throw new Error(data.error || data.message || rawText || `API request failed with status ${response.status}`);
+      }
+
       // 检查API响应格式 - 数据可能在data字段中
       const reportData = data.data || data;
       


### PR DESCRIPTION
## Summary
- read `/api/analyze` responses as text and parse JSON manually
- surface raw error text when parsing fails or status is not OK

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a145fbbfe88325ac694a8bdc0594ee